### PR TITLE
Remove Node.js version 18 from workflow matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
This pull request makes a minor update to the Node.js workflow configuration by removing support for Node.js version 18.x from the test matrix. The workflow will now only run tests for versions 20.x and 22.x.