### PR TITLE
Update Node.js version in workflow to 24.x

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
This pull request updates the Node.js versions used in the GitHub Actions workflow configuration. The workflow will now only run on Node.js version 24.x instead of multiple previous versions.

* GitHub Actions configuration: Updated the `node-version` matrix in `.github/workflows/node.js.yml` to run jobs only on Node.js 24.x, removing support for 18.x, 20.x, and 22.x.